### PR TITLE
Write timestamps to db instead of dates

### DIFF
--- a/src/Persist.hs
+++ b/src/Persist.hs
@@ -23,6 +23,7 @@ import qualified Data.Set as S
 import           Data.Text hiding (foldl, null, find, uncons, takeWhile, dropWhile, filter)
 import           Data.Text.Encoding (encodeUtf8)
 import           Data.Time.Calendar
+import           Data.Time.Clock (UTCTime (..), getCurrentTime)
 import           Data.Time.LocalTime
 import           Data.UUID as U
 import           System.Random (randomIO)
@@ -30,8 +31,8 @@ import           System.Random (randomIO)
 import           Types
 
 
-now :: Action IO Day
-now = liftIO $ localDay . zonedTimeToLocalTime <$> getZonedTime
+now :: Action IO UTCTime
+now = liftIO getCurrentTime 
 
 
 doc :: Value -> Document
@@ -253,7 +254,7 @@ instance ZettelEditor (Action IO) where
                      insert "session"
                        [ "id" =: sid
                        , "user" =: uid
-                       , "created" =: dayToGreg n ]
+                       , "created" =: n ]
                      return . Just $ Session sid uid n
           _ -> return Nothing
 


### PR DESCRIPTION
Update all dates to UTC timestamps.

Caveats:
* This includes info about when users, threads, etc are created. So these need to be changed in the db. 
* This requires the corresponding PR to the lib repo.